### PR TITLE
Manejo de imagenes de las maquinas

### DIFF
--- a/api/src/main/java/uni/ingsoft/maquinaria/model/request/MaquinaReqDto.java
+++ b/api/src/main/java/uni/ingsoft/maquinaria/model/request/MaquinaReqDto.java
@@ -3,10 +3,12 @@ package uni.ingsoft.maquinaria.model.request;
 import jakarta.validation.constraints.PositiveOrZero;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
 import java.time.LocalDate;
 
 @Builder
 @Getter
+@Setter
 public class MaquinaReqDto {
 	private String modelo;
 	private String nroSerie;

--- a/api/src/main/java/uni/ingsoft/maquinaria/utils/HandlerArchivos.java
+++ b/api/src/main/java/uni/ingsoft/maquinaria/utils/HandlerArchivos.java
@@ -1,0 +1,64 @@
+package uni.ingsoft.maquinaria.utils;
+
+import uni.ingsoft.maquinaria.utils.exceptions.ErrorCodes;
+import uni.ingsoft.maquinaria.utils.exceptions.MaquinariaExcepcion;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+
+public class HandlerArchivos {
+	public static String moverArchivoAPublicStorage(String source, String carpetaDestino, String filename) throws MaquinariaExcepcion {
+		if(source == null || carpetaDestino == null) {
+			return null;
+		}
+
+		File archivo = new File(source);
+		File dest = new File(carpetaDestino);
+
+		if(!archivo.isFile() || !archivo.canRead()) {
+			throw new MaquinariaExcepcion(ErrorCodes.ARCHIVO_NO_ENCONTRADO);
+		}
+
+		if(!dest.exists()) {
+			try {
+				dest.mkdir();
+			} catch(Exception e) {
+				throw new MaquinariaExcepcion(ErrorCodes.ALGO_SALIO_MAL);
+			}
+		}
+
+		if(!dest.isDirectory() || !dest.canWrite()) {
+			throw new MaquinariaExcepcion(ErrorCodes.ALGO_SALIO_MAL);
+		}
+
+		String extension = archivo.getName().substring(archivo.getName().lastIndexOf("."));
+		File archivoEnDestino = new File(carpetaDestino, filename + extension);
+
+		try {
+			Files.copy(archivo.getCanonicalFile().toPath(), archivoEnDestino.getCanonicalFile().toPath(), StandardCopyOption.COPY_ATTRIBUTES, StandardCopyOption.REPLACE_EXISTING);
+		} catch (IOException e) {
+			throw new MaquinariaExcepcion(ErrorCodes.ALGO_SALIO_MAL);
+		}
+
+		return archivoEnDestino.getName();
+	}
+
+	public static boolean eliminarArchivo(String source) throws MaquinariaExcepcion {
+		if(source == null) {
+			return true;
+		}
+
+		File archivo = new File(source);
+
+		if(!archivo.isFile() || !archivo.canWrite()) {
+			throw new MaquinariaExcepcion(ErrorCodes.ARCHIVO_NO_ENCONTRADO);
+		}
+
+		try {
+			return archivo.delete();
+		} catch(Exception e) {
+			return false;
+		}
+	}
+}

--- a/api/src/main/java/uni/ingsoft/maquinaria/utils/exceptions/ErrorCodes.java
+++ b/api/src/main/java/uni/ingsoft/maquinaria/utils/exceptions/ErrorCodes.java
@@ -9,6 +9,7 @@ public enum ErrorCodes {
 	 * 0x: Errores genericos
 	 */
 	ALGO_SALIO_MAL("00", HttpStatus.INTERNAL_SERVER_ERROR, "Algo salio mal."),
+	ARCHIVO_NO_ENCONTRADO("01", HttpStatus.BAD_REQUEST, "El archivo no se encuentra o no se tienen permisos."),
 
 	/*
 	 * 1x: Errores sobre Maquinas

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -13,3 +13,5 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
 springdoc.api-docs.path=/api-docs
 springdoc.swagger-ui.path=/swagger-ui.html
 springdoc.swagger-ui.url=/api-docs.yaml
+
+alav.public-storage.imagenes=../frontend/alav/public/imagenes


### PR DESCRIPTION
Las imagenes se copian a la carpeta `/public/imagenes` del front cuando se crea o edita una maquina, y se eliminan cuando se elimina la maquina
La imagen es opcional, si no hay imagen, en el json deberia venir el campo nulo

El nombre de los archivos es el numero de serie de la maquina, y eso es lo que queda tambien en la db; solo el nombre. Ya se sabe que la ubicacion es el `/public/imagenes` del front

Ejemplo REQUEST:
```json
{
  "nroSerie": "SN-010",
  "imagenDirec": "C:/users/marcelo/imagenes/imagen.png",
  ...
}
```

Ejemplo RESPONSE:
```json
{
  "nroSerie": "SN-010",
  "imagenDirec": "SN-010.png",
  ...
}
```