### PR TITLE
Anadir CORS globales

### DIFF
--- a/api/src/main/java/uni/ingsoft/maquinaria/CorsConfig.java
+++ b/api/src/main/java/uni/ingsoft/maquinaria/CorsConfig.java
@@ -1,0 +1,17 @@
+package uni.ingsoft.maquinaria;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig implements WebMvcConfigurer {
+	@Override
+	public void addCorsMappings(CorsRegistry registry) {
+		registry
+				.addMapping("/**")
+				.allowedOrigins("*")
+				.allowedMethods("*")
+				.allowedHeaders("*");
+	}
+}

--- a/api/src/main/java/uni/ingsoft/maquinaria/controller/InsumosControllers.java
+++ b/api/src/main/java/uni/ingsoft/maquinaria/controller/InsumosControllers.java
@@ -32,7 +32,6 @@ import uni.ingsoft.maquinaria.model.Insumos;
 
 @RestController
 @RequestMapping("/insumos")
-@CrossOrigin(origins = "*")
 public class InsumosControllers {
     @Autowired 
     private InsumosRepo insumosRepo;

--- a/api/src/main/java/uni/ingsoft/maquinaria/controller/MaquinaController.java
+++ b/api/src/main/java/uni/ingsoft/maquinaria/controller/MaquinaController.java
@@ -32,7 +32,6 @@ import java.util.Optional;
 @Validated
 @RestController
 @RequestMapping("/maquinas")
-@CrossOrigin(origins = "*")
 public class MaquinaController {
 	@Autowired MaquinaRepo maquinaRepo;
 	@Autowired MaquinaMapper maquinaMapper;

--- a/api/src/main/java/uni/ingsoft/maquinaria/controller/TareaController.java
+++ b/api/src/main/java/uni/ingsoft/maquinaria/controller/TareaController.java
@@ -31,7 +31,6 @@ import java.util.Optional;
 @Validated
 @RestController
 @RequestMapping("/tareas")
-@CrossOrigin(origins = "*")
 public class TareaController {
 	@Autowired TareaRepo tareaRepo;
 	@Autowired TareaMapper tareaMapper;

--- a/api/src/main/java/uni/ingsoft/maquinaria/controller/TecnicosController.java
+++ b/api/src/main/java/uni/ingsoft/maquinaria/controller/TecnicosController.java
@@ -31,7 +31,6 @@ import uni.ingsoft.maquinaria.model.Tecnicos;
 
 @RestController
 @RequestMapping("/tecnicos")
-@CrossOrigin(origins = "*")
 public class TecnicosController {
 	@Autowired
 	private TecnicosRepo tecnicosRepo;


### PR DESCRIPTION
Los CORS estaban configurados para los controllers, no incluia el servidor de archivos estaticos (las imagenes de las maquinas)